### PR TITLE
ignore min length for term with char in config

### DIFF
--- a/src/popup_dictionary/config.json
+++ b/src/popup_dictionary/config.json
@@ -5,6 +5,7 @@
     "dictionaryNoteTypeName": "Dictionary Entry",
     "dictionaryTermFieldName": "Term",
     "dictionaryDefinitionFieldName": "Definition",
+    "ignoreMinLength":"[]",
     "snippetsEnabled": true,
     "snippetsExcludedFields": ["Note ID", "ID (hidden)"],
     "snippetsLimitToCurrentDeck": true,

--- a/src/popup_dictionary/config.md
+++ b/src/popup_dictionary/config.md
@@ -10,6 +10,7 @@ Please note that the following settings do not sync and require a restart to app
 - `dictionaryTermFieldName` (string): Name of the dictionary term field in the dictionary note type. Default: `"Term"`.
 - `generalConfirmEmpty` (true/false): Whether or not to show tooltip when no results have been found. Default: `true`.
 - `generalHotkey` (string): Hotkey to invoke tooltip manually. Default: `"Ctrl+Shift+D"`.
+- `ignoreMinLength` (regex character set): If any of these characters are in term, ignore default minimum length the term must be(3)
 - `snippetsEnabled` (true/false): Whether or not to enable results drawn from any type of note in your collection. Default: `true`.
 - `snippetsExcludedFields` (list): List of fields to exclude from being shown in the note snippet section of the tooltip. Default: `["Note ID", "ID (hidden)"]`.
 - `snippetsLimitToCurrentDeck` (true/false): Whether or not to limit note snippet results to current deck. Default: `true`.

--- a/src/popup_dictionary/web.py
+++ b/src/popup_dictionary/web.py
@@ -36,6 +36,7 @@ JS libs
 from __future__ import unicode_literals
 
 from .consts import anki21, ADDON_VERSION
+from .config import CONFIG
 
 # jQuery v1.12.4 | (c) jQuery Foundation | jquery.org/license 
 jquery_js = r"""
@@ -173,7 +174,12 @@ $(document).ready(function()
         term = selection.toString().trim();
 
         // Return if selection empty or too short
-        if(term.length < 3){ return; }
+        var ignore =/%s/g
+        if(term.length < 3){
+             if(!(term.match(ignore))){
+                return;
+             }    
+        }
 
         // Exclude NID of clicked-on result entry
         if (element.id != "#qa"){
@@ -250,7 +256,7 @@ $(document).ready(function()
 
     qaTooltip = createTooltip("#qa");
 });
-""" % ("true" if anki21 else "false")
+""" % ("true" if anki21 else "false", CONFIG["ignoreMinLength"])
 
 # Custom tooltip CSS
 tooltip_css = r"""


### PR DESCRIPTION
#### Description

*Concisely describe what the pull request is trying to achieve. If pertinent, link to an existing issue report, or briefly explain the problem the PR is meant to solve. Feel free to attach screenshots or other media for UI-related changes.*

Allows users to specify a regex character set in config. When checking if length of the term is less than 3 and not providing dictionary if so, checks if the term contains any character in the character set and provide dictionary if so.

Useful for languages such as Korean, or Chinese, where there are many 2 length and 1 length words. (While English has only 26 possible 1 length letters, There are 11,172 possible 1 length letters in Korean for example)

Here is an example value of the config ignoreMinLength: 
[\u1100-\u11FF\u3130-\u318F\uA960-\uA97F\uAC00-\uD7AF\uD7B0-\uD7FF]

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x ] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ x] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [ ] I've tested my changes on at least one of the following platforms:
  - [ ] Linux, version:
  - [x] Windows, version: 10
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
