### PR TITLE
Add option to exclude new notes from snippet results

### DIFF
--- a/src/popup_dictionary/config.json
+++ b/src/popup_dictionary/config.json
@@ -7,6 +7,7 @@
     "dictionaryDefinitionFieldName": "Definition",
     "snippetsEnabled": true,
     "snippetsExcludedFields": ["Note ID", "ID (hidden)"],
+    "snippetsExcludeNewNotes": false,
     "snippetsLimitToCurrentDeck": true,
     "snippetsResultsWarnLimit": 1000
 }

--- a/src/popup_dictionary/config.md
+++ b/src/popup_dictionary/config.md
@@ -12,5 +12,6 @@ Please note that the following settings do not sync and require a restart to app
 - `generalHotkey` (string): Hotkey to invoke tooltip manually. Default: `"Ctrl+Shift+D"`.
 - `snippetsEnabled` (true/false): Whether or not to enable results drawn from any type of note in your collection. Default: `true`.
 - `snippetsExcludedFields` (list): List of fields to exclude from being shown in the note snippet section of the tooltip. Default: `["Note ID", "ID (hidden)"]`.
+- `snippetsExcludeNewNotes` (true/false): Whether or not to exclude snippet results from new notes. Default: `false`.
 - `snippetsLimitToCurrentDeck` (true/false): Whether or not to limit note snippet results to current deck. Default: `true`.
 - `snippetsResultsWarnLimit` (integer): Number of results above which to show a warning on the potential slowdowns they could cause. Set to `0` to disable warning. Default: `1000`.

--- a/src/popup_dictionary/results.py
+++ b/src/popup_dictionary/results.py
@@ -120,6 +120,9 @@ def getNoteSnippetsFor(term, ignore_nid):
     if conf["snippetsLimitToCurrentDeck"]:
         exclusion_tokens.append("deck:current")
 
+    if conf["snippetsExcludeNewNotes"]:
+        exclusion_tokens.append("-is:new")
+
     # construct query string
     query = u'''"{}" {}'''.format(term, " ".join(exclusion_tokens))
 


### PR DESCRIPTION
#### Description

*Concisely describe what the pull request is trying to achieve. If pertinent, link to an existing issue report, or briefly explain the problem the PR is meant to solve. Feel free to attach screenshots or other media for UI-related changes.*

Add option to exclude new notes from snippet results (fixes #15).
Notes with both new and non-new cards are included in the results.

#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [ ] Latest standard Anki 2.1 binary build [required for Anki-compatible 2.1 add-ons]
  - [ ] Latest alternative Anki 2.1 binary build
  - [x] Running Anki 2.1 from source (commit ed8340a)
  - [ ] Latest Anki 2.0 binary build [required for Anki 2.0-compatible add-ons]
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version: Debian bullseye
  - [ ] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
