### PR TITLE
Add sound marker removal regex

### DIFF
--- a/src/popup_dictionary/results.py
+++ b/src/popup_dictionary/results.py
@@ -80,6 +80,9 @@ html_field: str = """<div class="pdict-fld">{}</div>"""
 cloze_re_str = r"\{\{c(\d+)::(.*?)(::(.*?))?\}\}"
 cloze_re = re.compile(cloze_re_str)
 
+# RegExes for sound file marker removal
+sound_re_str = "\[.*?\.mp3\]"
+
 # Anki API shims
 
 
@@ -178,6 +181,8 @@ def get_note_snippets_for(term: str, ignore_nid: str) -> Union[List[str], bool, 
         joined_flds = "".join(valid_flds)
         # remove cloze markers
         filtered_flds = cloze_re.sub(r"\2", joined_flds)
+        # remove sound file markers
+        filtered_flds = re.sub(sound_re_str, ' ', filtered_flds)
         note_content.append(html_res_normal.format(nid, filtered_flds))
 
     return note_content


### PR DESCRIPTION
#### Description

*Sound file markers are replaced with a space, " ".  Consider the following marker.
[sound:......926fd104dec94c802cb89d61d1b8a6f.mp3], which constitutes a lot space in pop up dictionary and does not give any useful information by itself.*


#### Checklist:

*Please replace the space inside the brackets with an **x** and fill out the ellipses if the following items apply:*

- [x] I've read and understood the [contribution guidelines](./CONTRIBUTING.md)
- [x] I've tested my changes against at least one of the following [Anki builds](https://apps.ankiweb.net/#download):
  - [x] Latest standard Anki 2.1 binary build
  - [ ] Latest alternative Anki 2.1 binary build
- [x] I've tested my changes on at least one of the following platforms:
  - [x] Linux, version:
  - [x] Windows, version:
  - [ ] macOS, version: 
- [ ] My changes potentially affect non-desktop platforms, of which I've tested:
  - [ ] AnkiMobile, version:
  - [ ] AnkiDroid, version:
  - [ ] AnkiWeb
